### PR TITLE
Conditionally skip dex-preopting specific prebuilts.

### DIFF
--- a/core/prebuilt_internal.mk
+++ b/core/prebuilt_internal.mk
@@ -190,6 +190,11 @@ ifeq ($(DONT_DEXPREOPT_PREBUILTS),true)
 LOCAL_DEX_PREOPT := false
 endif
 
+# Disable dex-preopt of specific prebuilts to save space, if requested.
+ifneq ($(filter $(DEXPREOPT_BLACKLIST),$(LOCAL_MODULE)),)
+LOCAL_DEX_PREOPT := false
+endif
+
 #######################################
 # defines built_odex along with rule to install odex
 include $(BUILD_SYSTEM)/dex_preopt_odex_install.mk


### PR DESCRIPTION
Extend change I13f10e2a9c251366f29606158f8c2fb54f8ee8b so that it
optionally applies to a specific list of modules.

Change-Id: Id56aeadfb8d2581a2c7b7045725419bf4f6b8faa